### PR TITLE
Ntd1hc/bug/build for pypi fails due to missing dependencies

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -24,18 +24,18 @@ jobs:
           run: |
             sudo apt-get install -y pandoc
             sudo apt-get install -y texlive-latex-*
-            python -m pip install --upgrade build twine colorama pypandoc wheel dotdict GenPackageDoc PythonExtensionsCollection lxml MySQL-python
+            python -m pip install --upgrade build twine colorama pypandoc wheel
 
         - name: Build source and wheel distributions
           run: |
             python setup.py sdist bdist_wheel
             twine check --strict dist/*
 
-        - name: Publish distribution to PyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
-          with:
-            password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
-            # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
+        # - name: Publish distribution to PyPI
+        #   uses: pypa/gh-action-pypi-publish@release/v1
+        #   with:
+        #     password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
+        #     # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
 
         - name: Get Asset name
           run: |

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -24,7 +24,7 @@ jobs:
           run: |
             sudo apt-get install -y pandoc
             sudo apt-get install -y texlive-latex-*
-            python -m pip install --upgrade build twine colorama pypandoc wheel PythonExtensionsCollection
+            python -m pip install --upgrade build twine colorama pypandoc wheel PythonExtensionsCollection dotdict
 
         - name: Build source and wheel distributions
           run: |

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -24,7 +24,7 @@ jobs:
           run: |
             sudo apt-get install -y pandoc
             sudo apt-get install -y texlive-latex-*
-            python -m pip install --upgrade build twine colorama pypandoc wheel
+            python -m pip install --upgrade build twine colorama pypandoc wheel PythonExtensionsCollection
 
         - name: Build source and wheel distributions
           run: |

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -24,18 +24,18 @@ jobs:
           run: |
             sudo apt-get install -y pandoc
             sudo apt-get install -y texlive-latex-*
-            python -m pip install --upgrade build twine colorama pypandoc wheel PythonExtensionsCollection dotdict
+            python -m pip install --upgrade build twine wheel colorama pypandoc dotdict GenPackageDoc PythonExtensionsCollection
 
         - name: Build source and wheel distributions
           run: |
             python setup.py sdist bdist_wheel
             twine check --strict dist/*
 
-        # - name: Publish distribution to PyPI
-        #   uses: pypa/gh-action-pypi-publish@release/v1
-        #   with:
-        #     password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
-        #     # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
+        - name: Publish distribution to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
+            # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
 
         - name: Get Asset name
           run: |

--- a/PyTestLog2DB/__init__.py
+++ b/PyTestLog2DB/__init__.py
@@ -11,6 +11,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-from .pytestlog2db import PyTestLog2DB
-from .version import VERSION

--- a/PyTestLog2DB/__main__.py
+++ b/PyTestLog2DB/__main__.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from .pytestlog2db import PyTestLog2DB
+from PyTestLog2DB.pytestlog2db import PyTestLog2DB
 
 if __name__ == "__main__":
    PyTestLog2DB()

--- a/config/repository_config.json
+++ b/config/repository_config.json
@@ -13,7 +13,7 @@
    "DEVELOPMENTSTATUS" : "Development Status :: 4 - Beta",
    "INTENDEDAUDIENCE" : "Intended Audience :: Developers",
    "TOPIC" : "Topic :: Software Development",
-   "INSTALLREQUIRES" : ["pypandoc","colorama","mysqlclient","GenPackageDoc","PythonExtensionsCollection","lxml"],
+   "INSTALLREQUIRES" : ["colorama","mysqlclient","lxml"],
    "PACKAGEDATA" : ["*.pdf", "xsd/*.xsd"],
    "PACKAGEDOC" : "./packagedoc",
    "CONSOLESCRIPTS" : ["PyTestLog2DB = PyTestLog2DB.pytestlog2db:PyTestLog2DB"]

--- a/config/repository_config.json
+++ b/config/repository_config.json
@@ -13,7 +13,7 @@
    "DEVELOPMENTSTATUS" : "Development Status :: 4 - Beta",
    "INTENDEDAUDIENCE" : "Intended Audience :: Developers",
    "TOPIC" : "Topic :: Software Development",
-   "INSTALLREQUIRES" : ["pypandoc","colorama","mysqlclient","GenPackageDoc","PythonExtensionsCollection","lxml","MySQL-python"],
+   "INSTALLREQUIRES" : ["pypandoc","colorama","mysqlclient","GenPackageDoc","PythonExtensionsCollection","lxml"],
    "PACKAGEDATA" : ["*.pdf", "xsd/*.xsd"],
    "PACKAGEDOC" : "./packagedoc",
    "CONSOLESCRIPTS" : ["PyTestLog2DB = PyTestLog2DB.pytestlog2db:PyTestLog2DB"]


### PR DESCRIPTION
Hi Thomas,

This PR fixes issues #30 and #31.

As my investigation in comment https://github.com/test-fullautomation/python-genpackagedoc/issues/43#issuecomment-1527048109, I updated the build dependencies and package dependencies accordingly.

Please review and give your feeling about it.

Thank you,
Ngoan
