### PR TITLE
add missing requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+colorama
+pypandoc
+GenPackageDoc
+PythonExtensionsCollection


### PR DESCRIPTION
Hi Thomas,

This PR adds the missing `requirements.txt` which contains dependencies to run `setup.py` for installation.

Thank you,
Ngoan